### PR TITLE
Defined the encoding of the README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open('README.md') as f:
+with open('README.md', encoding="utf8") as f:
     readme = f.read()
 
 setuptools.setup(


### PR DESCRIPTION
Without specifying the encoding, the installation of the package fails on some systems.