### PR TITLE
Use newest versions of lxml and peewee

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         'arrow',
         'beautifulsoup4',
         'blessings',
-        'lxml==3.3.3',
+        'lxml',
         'requests',
-        'peewee==2.8.0'],
+        'peewee'],
 )


### PR DESCRIPTION
This fixes a build error while installing `lxml==3.3.3`.